### PR TITLE
Adiciona o abstract factory pattern

### DIFF
--- a/docs/criacional/abstract-factory/AbstractFactory.md
+++ b/docs/criacional/abstract-factory/AbstractFactory.md
@@ -1,0 +1,22 @@
+#### Abstract Factory Pattern
+
+O design pattern `Abstract Factory` fornece uma forma de agrupar várias factories que possuem o mesmo contexto, 
+sem a necessidade de especificar suas classes concretas. Com o intuito de exemplificar a implementação deste 
+padrão, foi criado esse esboço.
+
+Veja como fica a disposição das responsabilidades:
+
+* Client
+    * **IComputer**
+        * DellComputer
+            * DellKeyboard
+            * DellProcessor
+            * DellScreen
+    * **IComputerFactory**
+        * DellFactory
+
+Com o exemplo fornecido é possível criar cenários em que esse padrão seria facilmente implementado.
+
+Fonte: [Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Abstract_factory_pattern).
+
+[Retornar à página inicial](../../../README.md)

--- a/docs/criacional/abstract-factory/data/models/i-computer.ts
+++ b/docs/criacional/abstract-factory/data/models/i-computer.ts
@@ -1,0 +1,9 @@
+import {IScreen} from "./i-screen";
+import {IKeyboard} from "./i-keyboard";
+import {IProcessor} from "./i-processor";
+
+export interface IComputer {
+  screen: IScreen;
+  keyboard: IKeyboard;
+  processor: IProcessor;
+}

--- a/docs/criacional/abstract-factory/data/models/i-keyboard.ts
+++ b/docs/criacional/abstract-factory/data/models/i-keyboard.ts
@@ -1,0 +1,4 @@
+export interface IKeyboard {
+  type: string;
+  connectivity: string;
+}

--- a/docs/criacional/abstract-factory/data/models/i-processor.ts
+++ b/docs/criacional/abstract-factory/data/models/i-processor.ts
@@ -1,0 +1,4 @@
+export interface IProcessor {
+  performance: number;
+  socket: string;
+}

--- a/docs/criacional/abstract-factory/data/models/i-screen.ts
+++ b/docs/criacional/abstract-factory/data/models/i-screen.ts
@@ -1,0 +1,4 @@
+export interface IScreen {
+  size: number;
+  resolution: string;
+}

--- a/docs/criacional/abstract-factory/data/protocols/i-computer-factory.ts
+++ b/docs/criacional/abstract-factory/data/protocols/i-computer-factory.ts
@@ -1,0 +1,11 @@
+import {IScreen} from "../models/i-screen";
+import {IKeyboard} from "../models/i-keyboard";
+import {IProcessor} from "../models/i-processor";
+import {IComputer} from "../models/i-computer";
+
+export interface IComputerFactory<T extends IComputer> {
+  createComputer(): T;
+  createScreen(): IScreen;
+  createKeyboard(): IKeyboard;
+  createProcessor(): IProcessor;
+}

--- a/docs/criacional/abstract-factory/data/usecases/client.ts
+++ b/docs/criacional/abstract-factory/data/usecases/client.ts
@@ -1,0 +1,13 @@
+import {IComputerFactory} from "../protocols/i-computer-factory";
+import {IComputer} from "../models/i-computer";
+
+export class Client {
+  buildComputer<T extends IComputer>(factory: IComputerFactory<T>): T {
+    const computer = factory.createComputer();
+    computer.screen = factory.createScreen();
+    computer.keyboard = factory.createKeyboard();
+    computer.processor = factory.createProcessor();
+
+    return computer;
+  }
+}

--- a/docs/criacional/abstract-factory/domain/models/dell-computer.ts
+++ b/docs/criacional/abstract-factory/domain/models/dell-computer.ts
@@ -1,0 +1,10 @@
+import {IComputer} from "../../data/models/i-computer";
+import {DellKeyboard} from "./dell-keyboard";
+import {DellProcessor} from "./dell-processor";
+import {DellScreen} from "./dell-screen";
+
+export class DellComputer implements IComputer {
+  keyboard: DellKeyboard;
+  processor: DellProcessor;
+  screen: DellScreen;
+}

--- a/docs/criacional/abstract-factory/domain/models/dell-keyboard.ts
+++ b/docs/criacional/abstract-factory/domain/models/dell-keyboard.ts
@@ -1,0 +1,6 @@
+import {IKeyboard} from "../../data/models/i-keyboard";
+
+export class DellKeyboard implements IKeyboard {
+  connectivity: string;
+  type: string;
+}

--- a/docs/criacional/abstract-factory/domain/models/dell-processor.ts
+++ b/docs/criacional/abstract-factory/domain/models/dell-processor.ts
@@ -1,0 +1,6 @@
+import {IProcessor} from "../../data/models/i-processor";
+
+export class DellProcessor implements IProcessor {
+  performance: number;
+  socket: string;
+}

--- a/docs/criacional/abstract-factory/domain/models/dell-screen.ts
+++ b/docs/criacional/abstract-factory/domain/models/dell-screen.ts
@@ -1,0 +1,6 @@
+import {IScreen} from "../../data/models/i-screen";
+
+export class DellScreen implements IScreen {
+  resolution: string;
+  size: number;
+}

--- a/docs/criacional/abstract-factory/index.ts
+++ b/docs/criacional/abstract-factory/index.ts
@@ -1,0 +1,9 @@
+import {Client} from "./data/usecases/client";
+import {DellFactory} from "./main/factories/dell-factory";
+
+const client = new Client();
+const dellFactory = new DellFactory();
+
+const dellComputer = client.buildComputer(dellFactory);
+
+console.log(dellComputer);

--- a/docs/criacional/abstract-factory/main/factories/dell-factory.ts
+++ b/docs/criacional/abstract-factory/main/factories/dell-factory.ts
@@ -1,0 +1,24 @@
+import {IComputerFactory} from "../../data/protocols/i-computer-factory";
+import {DellComputer} from "../../domain/models/dell-computer";
+import {DellKeyboard} from "../../domain/models/dell-keyboard";
+import {DellProcessor} from "../../domain/models/dell-processor";
+import {DellScreen} from "../../domain/models/dell-screen";
+
+export class DellFactory implements IComputerFactory<DellComputer> {
+  createComputer(): DellComputer {
+    return new DellComputer();
+  }
+
+  createKeyboard(): DellKeyboard {
+    return new DellKeyboard();
+  }
+
+  createProcessor(): DellProcessor {
+    return new DellProcessor();
+  }
+
+  createScreen(): DellScreen {
+    return new DellScreen();
+  }
+
+}


### PR DESCRIPTION
Foi criado um exemplo simples da implementação do pattern Abstract Factory. A pasta referente ao pattern possui um README com uma breve explicação sobre o pattern.